### PR TITLE
Add FluidAudio - Swift speaker diarization library for MacOS / iOS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Team in the Inaugural DIHARD Challenge](https://www.isca-speech.org/archive/pdfs
 | [Picovoice Falcon](https://github.com/Picovoice/falcon) ![GitHub stars](https://img.shields.io/github/stars/Picovoice/falcon?style=social) | C & Python | A [lightweight, accurate, and fast](https://picovoice.ai/docs/benchmark/speaker-diarization/#accuracy) speaker diarization engine written in C and available in Python, running on CPU with minimal overhead. |
 | [DiaPer](https://github.com/BUTSpeechFIT/DiaPer) ![GitHub stars](https://img.shields.io/github/stars/BUTSpeechFIT/DiaPer?style=social) | Python | Pytorch implementation for [DiaPer: End-to-End Neural Diarization with Perceiver-Based Attractors](https://arxiv.org/pdf/2312.04324.pdf) including models pre-trained on free and public data. |
 | [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx) ![GitHub stars](https://img.shields.io/github/stars/k2-fsa/sherpa-onnx?style=social) | C++ & C & `C#` & Dart & Go & Java & JavaScript & Kotlin & Pascal & Python & Rust & Swift | Support speaker diarization, speech recognition, and text-to speech on various platforms with various language bindings. |
+| [FluidAudio](https://github.com/FluidInference/FluidAudio) ![GitHub stars](https://img.shields.io/github/stars/FluidInference/FluidAudio?style=social) | Swift | A native Swift speaker diarization library for Apple platforms, using CoreML for efficient, real-time audio processing with high accuracy. |
 
 
 ### Evaluation


### PR DESCRIPTION
  ## Summary
  - FluidAudio is a native Swift speaker diarization library optimized for
  Apple platforms using CoreML converted from Sherpa ONNX

  ## Why this addition?
Our team needed a diarization solution that could run every few seconds with transcription on iOS and macOS, but native Swift support was sparse. [sherpa-onnx ](https://github.com/k2-fsa/sherpa-onnx/tree/master/ios-swift/SherpaOnnx) worked, but we had some performance issue during real time especially on older devices to support our users on M1 Macs, we wanted to move more of the workload to the ANE.

Rather than forcing the ONNX model into CoreML, we converted the original PyTorch models directly to CoreML, avoiding the C++ glue code entirely.

  ## Details
  - **Repository**: https://github.com/FluidInference/FluidAudio
  - **Language**: Swift
  - **Key features**: CoreML optimization, VAD model support too, real-time
  processing, Apple Neural Engine support
  - **Platforms**: macOS 13.0+, iOS 16.0+