### PR TITLE
Add Timepiecepedia Watch Database to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Team in the Inaugural DIHARD Challenge](https://www.isca-speech.org/archive/pdfs
 
 ## Datasets
 
+- [Timepiecepedia Watch Database](https://github.com/timepiecepedia/timepiecepedia-data) — Free CC0 dataset: 25,876+ watch references across 126 brands, with full specifications (movement, material, diameter, water resistance), imagery URLs, and watchmaking glossary.
 ### Diarization datasets
 
 | Audio | Diarization ground truth | Language | Pricing | Additional information |


### PR DESCRIPTION
Hi! 👋

Thought this would fit your "Datasets" section:

**[Timepiecepedia Watch Database](https://github.com/timepiecepedia/timepiecepedia-data)** — a free, CC0-licensed open dataset of 25,876+ watch references across 126 brands, with full specs (movement, case, materials, water resistance), image URLs, and 1,075+ horology terms. The dataset is auto-updated every few hours from [timepiecepedia.com](https://timepiecepedia.com).

Use cases: ML training, watch comparison tools, horology research, collector apps.

No obligation to merge — feel free to close or edit as you see fit. Thanks for maintaining a great list!